### PR TITLE
Add missing connection parameters

### DIFF
--- a/src/interfaces/nest-pgpromise-options.interface.ts
+++ b/src/interfaces/nest-pgpromise-options.interface.ts
@@ -6,6 +6,15 @@ export interface NestPgpromiseOptions {
         database: string;
         user: string;
         password: string;
+        ssl: boolean;
+        binary: boolean;
+        client_encoding: string;
+        application_name: string;
+        fallback_application_name: string;
+        idleTimeoutMillis: number;
+        max: number;
+        query_timeout: number;
+        keepAlive: boolean;
       }
     | string;
   initOptions?: {


### PR DESCRIPTION
I needed to enable ssl to connect to Heroku so I added these extra parameters and they worked fine. All of them are from the documentation:
https://github.com/vitaly-t/pg-promise/wiki/Connection-Syntax